### PR TITLE
auth: handle AUTH_KEY_DUPLICATED the same as 401s

### DIFF
--- a/telegram/auth/auth.go
+++ b/telegram/auth/auth.go
@@ -12,9 +12,12 @@ func IsKeyUnregistered(err error) bool {
 	return tgerr.Is(err, "AUTH_KEY_UNREGISTERED")
 }
 
-// IsUnauthorized reports whether err is 401 UNAUTHORIZED.
+// IsUnauthorized reports whether err is any 401 UNAUTHORIZED or is a 406
+// NOT_ACCEPTABLE with AUTH_KEY_DUPLICATED.
 //
 // https://core.telegram.org/api/errors#401-unauthorized
+// https://core.telegram.org/api/errors#406-not-acceptable
 func IsUnauthorized(err error) bool {
-	return tgerr.IsCode(err, 401)
+	return tgerr.IsCode(err, 401) ||
+		(tgerr.IsCode(err, 406) && tgerr.Is(err, "AUTH_KEY_DUPLICATED"))
 }


### PR DESCRIPTION
Signed-off-by: Sumner Evans <sumner.evans@automattic.com>
