### PR TITLE
download/stream: don't always assume a single block

### DIFF
--- a/telegram/downloader/stream_reader.go
+++ b/telegram/downloader/stream_reader.go
@@ -45,5 +45,5 @@ func (d *Downloader) streamToReader(ctx context.Context, r *reader) (tg.StorageF
 	if err != nil {
 		return nil, nil, err
 	}
-	return first.tag, &streamReader{ctx, r, first, false}, nil
+	return first.tag, &streamReader{ctx, r, first, first.last()}, nil
 }


### PR DESCRIPTION
`streamReader` initially fixes `last` to be `false` when being instantiated, which only actually holds if the entire data stream is larger than the part size[^1]. But because we only ever update `last` after a new chunk is received, we would attempt to request the nonexistent next chunk if the first chunk is small enough. For whatever reason, requesting an out-of-bound chunk like this results in a stall, followed by a misleading "Timeout" (code -503) error from Telegram despite nothing actually timing out. We also don't properly bubble up this error to the client, but that can be a separate patch.

We recently bumped this value to 1 MiB[^2], which probably increased the likelihood of this failure mode, despite being extant before. To fix this, initialize `last` to the appropriate value, which we're able to ascertain due to knowing the size of both the streaming buffer and the chunk itself.

[^1]: https://github.com/beeper/td/blob/77127ad042c41172f9c32abb4c2a02bf89657752/telegram/downloader/downloader.go#L26
[^2]: https://github.com/mautrix/telegramgo/blob/c96a24179495fdf7e360f57d9dcbebea72482327/pkg/connector/media/transfer.go#L336