### PR TITLE
updates: don't just log update handler errors, respect them and avoid updating state

### DIFF
--- a/telegram/updates/config.go
+++ b/telegram/updates/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	Handler telegram.UpdateHandler
 	// Callback called if manager cannot
 	// recover channel gap (optional).
-	OnChannelTooLong func(channelID int64)
+	OnChannelTooLong func(channelID int64) error
 	// State storage.
 	// In-mem used if not provided.
 	Storage StateStorage
@@ -54,8 +54,9 @@ func (cfg *Config) setDefaults() {
 		cfg.Storage = newMemStorage()
 	}
 	if cfg.OnChannelTooLong == nil {
-		cfg.OnChannelTooLong = func(channelID int64) {
+		cfg.OnChannelTooLong = func(channelID int64) error {
 			cfg.Logger.Error("Difference too long", zap.Int64("channel_id", channelID))
+			return nil
 		}
 	}
 }

--- a/telegram/updates/state.go
+++ b/telegram/updates/state.go
@@ -50,7 +50,7 @@ type internalState struct {
 	client    API
 	log       *zap.Logger
 	handler   telegram.UpdateHandler
-	onTooLong func(channelID int64)
+	onTooLong func(channelID int64) error
 	storage   StateStorage
 	hasher    AccessHasher
 	selfID    int64
@@ -69,7 +69,7 @@ type stateConfig struct {
 	Logger           *zap.Logger
 	Tracer           trace.Tracer
 	Handler          telegram.UpdateHandler
-	OnChannelTooLong func(channelID int64)
+	OnChannelTooLong func(channelID int64) error
 	Storage          StateStorage
 	Hasher           AccessHasher
 	SelfID           int64
@@ -176,18 +176,12 @@ func (s *internalState) Run(ctx context.Context) error {
 		case u := <-s.externalQueue:
 			ctx := trace.ContextWithSpanContext(ctx, u.span)
 			if err := s.handleUpdates(ctx, u.update); err != nil {
-				s.log.Error("Handle updates error", zap.Error(err))
-				if isFatalError(err) {
-					return errors.Wrap(err, "fatal error")
-				}
+				return err
 			}
 		case u := <-s.internalQueue:
 			ctx := trace.ContextWithSpanContext(ctx, u.span)
 			if err := s.handleUpdates(ctx, u.update); err != nil {
-				s.log.Error("Handle updates error", zap.Error(err))
-				if isFatalError(err) {
-					return errors.Wrap(err, "fatal error")
-				}
+				return err
 			}
 		case <-s.pts.gapTimeout.C:
 			s.log.Debug("Pts gap timeout")
@@ -461,7 +455,7 @@ func (s *internalState) getDifference(ctx context.Context) error {
 				Users: diff.Users,
 				Chats: diff.Chats,
 			}); err != nil {
-				s.log.Error("Handle updates error", zap.Error(err))
+				return err
 			}
 		}
 
@@ -487,7 +481,7 @@ func (s *internalState) getDifference(ctx context.Context) error {
 				Chats:   diff.Chats,
 				Date:    diff.IntermediateState.Date,
 			}); err != nil {
-				s.log.Error("Handle updates error", zap.Error(err))
+				return err
 			}
 		}
 
@@ -500,7 +494,7 @@ func (s *internalState) getDifference(ctx context.Context) error {
 				Users: diff.Users,
 				Chats: diff.Chats,
 			}); err != nil {
-				s.log.Error("Handle updates error", zap.Error(err))
+				return err
 			}
 		}
 

--- a/telegram/updates/state_apply.go
+++ b/telegram/updates/state_apply.go
@@ -23,7 +23,7 @@ func (s *internalState) applySeq(ctx context.Context, state int, updates []updat
 	}
 
 	if err := s.storage.SetSeq(ctx, s.selfID, state); err != nil {
-		s.log.Error("SetSeq error", zap.Error(err))
+		return err
 	}
 
 	if recoverState {
@@ -61,7 +61,7 @@ func (s *internalState) applyCombined(ctx context.Context, comb *tg.UpdatesCombi
 				entities: ents,
 				span:     trace.SpanContextFromContext(ctx),
 			}); err != nil {
-				s.log.Error("Push channel update error", zap.Error(err))
+				return false, err
 			}
 			continue
 		}
@@ -82,7 +82,7 @@ func (s *internalState) applyCombined(ctx context.Context, comb *tg.UpdatesCombi
 				entities: ents,
 				span:     trace.SpanContextFromContext(ctx),
 			}); err != nil {
-				s.log.Error("Handle channel update error", zap.Error(err))
+				return false, err
 			}
 		}
 
@@ -98,26 +98,26 @@ func (s *internalState) applyCombined(ctx context.Context, comb *tg.UpdatesCombi
 		Users:   ents.Users,
 		Chats:   ents.Chats,
 	}); err != nil {
-		s.log.Error("Handle updates error", zap.Error(err))
+		return false, err
 	}
 
 	setDate, setSeq := comb.Date > s.date, comb.Seq > 0
 	switch {
 	case setDate && setSeq:
 		if err := s.storage.SetDateSeq(ctx, s.selfID, comb.Date, comb.Seq); err != nil {
-			s.log.Error("SetDateSeq error", zap.Error(err))
+			return false, err
 		}
 
 		s.date = comb.Date
 		s.seq.SetState(comb.Seq, "seq update")
 	case setDate:
 		if err := s.storage.SetDate(ctx, s.selfID, comb.Date); err != nil {
-			s.log.Error("SetDate error", zap.Error(err))
+			return false, err
 		}
 		s.date = comb.Date
 	case setSeq:
 		if err := s.storage.SetSeq(ctx, s.selfID, comb.Seq); err != nil {
-			s.log.Error("SetSeq error", zap.Error(err))
+			return false, err
 		}
 		s.seq.SetState(comb.Seq, "seq update")
 	}
@@ -144,11 +144,11 @@ func (s *internalState) applyPts(ctx context.Context, state int, updates []updat
 		Users:   ents.Users,
 		Chats:   ents.Chats,
 	}); err != nil {
-		s.log.Error("Handle updates error", zap.Error(err))
+		return err
 	}
 
 	if err := s.storage.SetPts(ctx, s.selfID, state); err != nil {
-		s.log.Error("SetPts error", zap.Error(err))
+		return err
 	}
 
 	return nil
@@ -173,7 +173,7 @@ func (s *internalState) applyQts(ctx context.Context, state int, updates []updat
 		Users:   ents.Users,
 		Chats:   ents.Chats,
 	}); err != nil {
-		s.log.Error("Handle updates error", zap.Error(err))
+		return err
 	}
 
 	// Don't set qts if it's 0, because it means that we are apllying gaps updates
@@ -182,7 +182,7 @@ func (s *internalState) applyQts(ctx context.Context, state int, updates []updat
 	}
 
 	if err := s.storage.SetQts(ctx, s.selfID, state); err != nil {
-		s.log.Error("SetQts error", zap.Error(err))
+		return err
 	}
 
 	return nil

--- a/telegram/updates/state_channel.go
+++ b/telegram/updates/state_channel.go
@@ -39,7 +39,7 @@ type channelState struct {
 	log        *zap.Logger
 	tracer     trace.Tracer
 	handler    telegram.UpdateHandler
-	onTooLong  func(channelID int64)
+	onTooLong  func(channelID int64) error
 }
 
 type channelStateConfig struct {
@@ -52,7 +52,7 @@ type channelStateConfig struct {
 	RawClient        API
 	Storage          StateStorage
 	Handler          telegram.UpdateHandler
-	OnChannelTooLong func(channelID int64)
+	OnChannelTooLong func(channelID int64) error
 	Logger           *zap.Logger
 	Tracer           trace.Tracer
 }
@@ -169,8 +169,7 @@ func (s *channelState) handleTooLong(ctx context.Context, long *tg.UpdateChannel
 	// Note: we still can fetch latest diffLim updates.
 	// Should we do?
 	if remotePts-s.pts.State() > s.diffLim {
-		s.onTooLong(s.channelID)
-		return nil
+		return s.onTooLong(s.channelID)
 	}
 
 	return s.getDifference(ctx)
@@ -276,7 +275,7 @@ func (s *channelState) getDifference(ctx context.Context) error {
 				Users:   diff.Users,
 				Chats:   diff.Chats,
 			}); err != nil {
-				s.log.Error("Handle updates error", zap.Error(err))
+				return err
 			}
 		}
 
@@ -323,8 +322,7 @@ func (s *channelState) getDifference(ctx context.Context) error {
 			s.pts.SetState(remotePts, "updates.channelDifferenceTooLong dialog new pts")
 		}
 
-		s.onTooLong(s.channelID)
-		return nil
+		return s.onTooLong(s.channelID)
 
 	default:
 		return errors.Errorf("unexpected channel diff type: %T", diff)


### PR DESCRIPTION
don't update state trackers if an update fails to be handled

necessary to avoid persisting gaps that never get filled